### PR TITLE
Send AttributeModified on touch

### DIFF
--- a/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
@@ -50,7 +50,7 @@ namespace fsw
     flags.push_back({kFSEventStreamEventFlagUnmount, fsw_event_flag::PlatformSpecific});
     flags.push_back({kFSEventStreamEventFlagItemCreated, fsw_event_flag::Created});
     flags.push_back({kFSEventStreamEventFlagItemRemoved, fsw_event_flag::Removed});
-    flags.push_back({kFSEventStreamEventFlagItemInodeMetaMod, fsw_event_flag::PlatformSpecific});
+    flags.push_back({kFSEventStreamEventFlagItemInodeMetaMod, fsw_event_flag::AttributeModified});
     flags.push_back({kFSEventStreamEventFlagItemRenamed, fsw_event_flag::Renamed});
     flags.push_back({kFSEventStreamEventFlagItemModified, fsw_event_flag::Updated});
     flags.push_back({kFSEventStreamEventFlagItemFinderInfoMod, fsw_event_flag::PlatformSpecific});


### PR DESCRIPTION
As proposed in https://github.com/emcrisostomo/fswatch/issues/243#issuecomment-642493362, send `AttributeModified` in response to `kFSEventStreamEventFlagItemInodeMetaMod`.